### PR TITLE
Depend on v0.18.0 repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.6",
 ]
@@ -225,9 +225,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -335,15 +335,24 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -451,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -463,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -478,15 +487,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -505,12 +514,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.3",
- "darling_macro 0.14.3",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -529,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -554,11 +563,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.3",
+ "darling_core 0.14.4",
  "quote",
  "syn",
 ]
@@ -578,7 +587,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -698,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "get-size"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26b72209bdcd38f3fdf606f37658229b55acc3780d9c5456613a7fed149bc1b"
+checksum = "016d98c5465aa9c741e4e520b307375d0c15f6a1670fee78f37b1a2e706deff0"
 dependencies = [
  "get-size-derive",
 ]
@@ -896,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
@@ -910,6 +919,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,9 +935,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libm"
@@ -1350,18 +1368,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1470,9 +1488,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -1480,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1530,9 +1548,9 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-leveldb"
@@ -1550,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -1571,42 +1589,33 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-big-array"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bb66e1af4481c21cbc943cabb68b98aabb4d7f935e47d1b4de722ca09da0b4"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1615,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -1636,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
+checksum = "85456ffac572dc8826334164f2fb6fb40a7c766aebe195a2a21ee69ee2885ecf"
 dependencies = [
  "base64",
  "chrono",
@@ -1646,7 +1655,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_with_macros 2.2.0",
+ "serde_with_macros 2.3.1",
  "time",
 ]
 
@@ -1664,11 +1673,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
+checksum = "7cbcd6104f8a4ab6af7f6be2a0da6be86b9de3c401f6e86bb856ab2af739232f"
 dependencies = [
- "darling 0.14.3",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -1791,7 +1800,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tasm-lang"
-version = "0.1.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
@@ -1801,15 +1810,15 @@ dependencies = [
  "rand 0.8.5",
  "syn",
  "tasm-lib",
- "triton-opcodes 0.14.0 (git+https://github.com/TritonVM/triton-vm.git?branch=master)",
- "triton-vm 0.14.0",
- "twenty-first 0.14.1",
+ "triton-opcodes",
+ "triton-vm",
+ "twenty-first",
 ]
 
 [[package]]
 name = "tasm-lib"
 version = "0.1.0"
-source = "git+https://github.com/TritonVM/tasm-lib#095a35c814ae23409a47cd0d89bf31cccf955bca"
+source = "git+https://github.com/TritonVM/tasm-lib#1a02d0b8f3f76d50056e5e66adaaddd72229c752"
 dependencies = [
  "itertools",
  "num",
@@ -1818,9 +1827,9 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "triton-opcodes 0.14.0 (git+https://github.com/TritonVM/triton-vm.git?branch=master)",
- "triton-vm 0.15.0",
- "twenty-first 0.14.1",
+ "triton-opcodes",
+ "triton-vm",
+ "twenty-first",
 ]
 
 [[package]]
@@ -1892,9 +1901,9 @@ checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1903,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "triton-opcodes"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b992336d142f271e98440932e6947dbb2c838a5ed8bdb3ec61533e17a97d58"
+checksum = "7db4812831dd2d3b69ab13cb19c9e151976977fe3fc9234f23a8776cac30ff16"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1915,30 +1924,14 @@ dependencies = [
  "regex",
  "strum",
  "strum_macros",
- "twenty-first 0.14.1",
-]
-
-[[package]]
-name = "triton-opcodes"
-version = "0.14.0"
-source = "git+https://github.com/TritonVM/triton-vm.git?branch=master#c1be5bb92c47e7cb55b11355a33f7b1eb8aeff94"
-dependencies = [
- "anyhow",
- "itertools",
- "nom",
- "num-traits",
- "rand 0.8.5",
- "regex",
- "strum",
- "strum_macros",
- "twenty-first 0.14.1",
+ "twenty-first",
 ]
 
 [[package]]
 name = "triton-profiler"
-version = "0.13.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc302cde40db3c3c6bf6831bf221062c10077b29301ed3df075c2789b12d07cb"
+checksum = "4fa7004a8ded367c5a2e5c5876ae84f0039d015956c158846c64ec30b92dac4e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1965,106 +1958,22 @@ dependencies = [
  "ring",
  "rusty-leveldb",
  "serde",
- "serde-big-array 0.5.0",
+ "serde-big-array",
  "serde_derive",
  "serde_json",
- "serde_with 2.2.0",
+ "serde_with 2.3.1",
  "structopt",
  "strum",
  "strum_macros",
- "twenty-first 0.11.0",
- "unicode-width",
-]
-
-[[package]]
-name = "triton-profiler"
-version = "0.13.0"
-source = "git+https://github.com/TritonVM/triton-vm.git?branch=master#c1be5bb92c47e7cb55b11355a33f7b1eb8aeff94"
-dependencies = [
- "anyhow",
- "bincode",
- "blake3",
- "byteorder",
- "colored",
- "console",
- "criterion",
- "hashbrown 0.13.2",
- "itertools",
- "nom",
- "num-bigint",
- "num-traits",
- "parity-scale-codec",
- "paw",
- "phf 0.11.1",
- "primitive-types 0.12.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "rand_distr",
- "rand_pcg",
- "rayon",
- "ring",
- "rusty-leveldb",
- "serde",
- "serde-big-array 0.5.0",
- "serde_derive",
- "serde_json",
- "serde_with 2.2.0",
- "structopt",
- "strum",
- "strum_macros",
- "twenty-first 0.14.1",
+ "twenty-first",
  "unicode-width",
 ]
 
 [[package]]
 name = "triton-vm"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f2d9066f34155da0d7801c6b49953f5c3c0b947155c432ea3dbbd980ad5c3d"
-dependencies = [
- "anyhow",
- "bincode",
- "blake3",
- "byteorder",
- "colored",
- "console",
- "hashbrown 0.13.2",
- "itertools",
- "ndarray",
- "nom",
- "num-bigint",
- "num-traits",
- "parity-scale-codec",
- "paw",
- "phf 0.11.1",
- "primitive-types 0.12.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "rand_distr",
- "rand_pcg",
- "rayon",
- "regex",
- "ring",
- "rusty-leveldb",
- "serde",
- "serde-big-array 0.4.1",
- "serde_derive",
- "serde_json",
- "serde_with 2.2.0",
- "structopt",
- "strum",
- "strum_macros",
- "triton-opcodes 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "triton-profiler 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "twenty-first 0.14.1",
-]
-
-[[package]]
-name = "triton-vm"
-version = "0.15.0"
-source = "git+https://github.com/TritonVM/triton-vm.git?branch=prerelease-0.15.0#3b04b8b8b960560462e4cc81f2bc4c3046682919"
+checksum = "2d68e0b34327895ca1bedafaf26b72711c51b818fdb12f05cfbfa530e3605922"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2091,23 +2000,23 @@ dependencies = [
  "ring",
  "rusty-leveldb",
  "serde",
- "serde-big-array 0.4.1",
+ "serde-big-array",
  "serde_derive",
  "serde_json",
- "serde_with 2.2.0",
+ "serde_with 2.3.1",
  "structopt",
  "strum",
  "strum_macros",
- "triton-opcodes 0.14.0 (git+https://github.com/TritonVM/triton-vm.git?branch=master)",
- "triton-profiler 0.13.0 (git+https://github.com/TritonVM/triton-vm.git?branch=master)",
- "twenty-first 0.14.1",
+ "triton-opcodes",
+ "triton-profiler",
+ "twenty-first",
 ]
 
 [[package]]
 name = "twenty-first"
-version = "0.11.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2055db373502fef8bf3dbfe27e1fbc08bb4a3505f1a046a9f7d8f118040afda"
+checksum = "bedaa827a42ffa7930261d71b07b53a91ca7aaca9c399d2ef6ea4fcfa3b013e6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2119,6 +2028,7 @@ dependencies = [
  "get-size",
  "hashbrown 0.12.3",
  "itertools",
+ "keccak",
  "nom",
  "num-bigint",
  "num-traits",
@@ -2134,49 +2044,12 @@ dependencies = [
  "ring",
  "rusty-leveldb",
  "serde",
- "serde-big-array 0.5.0",
+ "serde-big-array",
  "serde_derive",
  "serde_json",
  "serde_with 1.14.0",
  "structopt",
-]
-
-[[package]]
-name = "twenty-first"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5dd3f9c81a9ca1f4cc06420efa7afdd8fda31b38b5890ff625c93db0b1fdb2"
-dependencies = [
- "anyhow",
- "bincode",
- "blake3",
- "byteorder",
- "colored",
- "console",
- "emojihash-rs",
- "get-size",
- "hashbrown 0.12.3",
- "itertools",
- "nom",
- "num-bigint",
- "num-traits",
- "parity-scale-codec",
- "paw",
- "phf 0.10.1",
- "primitive-types 0.11.1",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "rand_distr",
- "rand_pcg",
- "rayon",
- "ring",
- "rusty-leveldb",
- "serde",
- "serde-big-array 0.5.0",
- "serde_derive",
- "serde_json",
- "serde_with 1.14.0",
- "structopt",
+ "unroll",
 ]
 
 [[package]]
@@ -2199,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2214,6 +2087,16 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unroll"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "untrusted"
@@ -2368,51 +2251,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ triton-vm = "0.18.0"
 itertools = "0.10"
 num = "0.4"
 quote = "1.0"
-rand = "0.8.5"
+rand = "0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-anyhow = "1.0"
+anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasm-lang"
-version = "0.1.0"
+version = "0.18.0"
 edition = "2021"
 
 [dev-dependencies.cargo-husky]
@@ -10,12 +10,12 @@ features = ["precommit-hook", "run-cargo-test", "run-cargo-clippy", "run-cargo-f
 
 [dependencies]
 tasm-lib = { git = "https://github.com/TritonVM/tasm-lib" }
-twenty-first = "0.14"
-triton-opcodes = { version = "0.14", git = "https://github.com/TritonVM/triton-vm.git", branch = "master" }
-triton-vm = { version = "0.14"}
+twenty-first = "0.18.0"
+triton-opcodes = "0.18.0"
+triton-vm = "0.18.0"
 itertools = "0.10"
 num = "0.4"
 quote = "1.0"
-rand = "*"
+rand = "0.8.5"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-anyhow = "*"
+anyhow = "1.0"

--- a/src/graft.rs
+++ b/src/graft.rs
@@ -86,11 +86,10 @@ fn pat_type_to_data_type(rust_type_path: &syn::PatType) -> (ast::DataType, bool)
 }
 
 fn pat_to_name(pat: &syn::Pat) -> String {
-    let name = match pat {
+    match pat {
         syn::Pat::Ident(ident) => ident.ident.to_string(),
         other => panic!("unsupported: {other:?}"),
-    };
-    name
+    }
 }
 
 fn path_to_ident(path: &syn::Path) -> String {
@@ -353,11 +352,11 @@ pub fn graft_expr(rust_exp: &syn::Expr) -> ast::Expr<Annotation> {
                 syn::Expr::Block(block) => {
                     let else_branch = &block.block.stmts;
                     assert_eq!(1, else_branch.len(), "Max one line in if/else expressions");
-                    let else_branch = match &else_branch[0] {
+
+                    match &else_branch[0] {
                         syn::Stmt::Expr(expr) => graft_expr(expr),
                         other => panic!("unsupported: {other:?}"),
-                    };
-                    else_branch
+                    }
                 }
                 other => panic!("unsupported: {other:?}"),
             };

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,19 +7,14 @@ use crate::ast;
 use crate::libraries::tasm;
 use crate::libraries::vector;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Hash, PartialEq, Eq)]
 pub enum Typing {
     /// An `UnknownType` has not been determined; this is produced by the parser/grafter.
+    #[default]
     UnknownType,
 
     /// A `KnownType` has been determined; this is performed by the type checker.
     KnownType(ast::DataType),
-}
-
-impl Default for Typing {
-    fn default() -> Self {
-        Typing::UnknownType
-    }
 }
 
 impl GetType for Typing {


### PR DESCRIPTION
Set version to v0.18.0.

Run `cargo update`.

`cargo clean; cargo test` succeeds.

`cargo clippy --all-targets` succeeds.