### PR TITLE
Versatile shift operators

### DIFF
--- a/src/tasm_code_generator.rs
+++ b/src/tasm_code_generator.rs
@@ -1266,26 +1266,51 @@ fn compile_expr(
                 ast::BinOp::Rem => todo!(),
 
                 ast::BinOp::Shl => {
-                    // For now we can only `1 << n` for some n
-                    let lhs_expr_owned = *lhs_expr.to_owned();
-                    if !matches!(lhs_expr_owned, ast::Expr::Lit(ast::ExprLit::U64(1))) {
-                        panic!("Unsupported shift left: {lhs_expr_owned:#?}")
-                    }
+                    let (_lhs_expr_addr, lhs_expr_code) =
+                        compile_expr(lhs_expr, "_binop_lhs", &lhs_type, state);
 
                     let (_rhs_expr_addr, rhs_expr_code) =
                         compile_expr(rhs_expr, "_binop_rhs", &rhs_type, state);
 
-                    let pow2_fn =
-                        state.import_snippet(Box::new(arithmetic::u64::pow2_u64::Pow2U64));
-                    let code = vec![rhs_expr_code, vec![call(pow2_fn)]].concat();
+                    let shl = if matches!(lhs_expr.to_owned().get_type(), ast::DataType::U32) {
+                        state.import_snippet(Box::new(arithmetic::u32::shift_left::ShiftLeftU32))
+                    } else {
+                        state
+                            .import_snippet(Box::new(arithmetic::u64::shift_left_u64::ShiftLeftU64))
+                    };
 
+                    let code = vec![lhs_expr_code, rhs_expr_code, vec![call(shl)]].concat();
+
+                    state.vstack.pop();
                     state.vstack.pop();
                     let addr = state.new_value_identifier("_binop_shl", &res_type);
 
                     (addr, code)
                 }
 
-                ast::BinOp::Shr => todo!(),
+                ast::BinOp::Shr => {
+                    let (_lhs_expr_addr, lhs_expr_code) =
+                        compile_expr(lhs_expr, "_binop_lhs", &lhs_type, state);
+
+                    let (_rhs_expr_addr, rhs_expr_code) =
+                        compile_expr(rhs_expr, "_binop_rhs", &rhs_type, state);
+
+                    let shr = if matches!(lhs_expr.to_owned().get_type(), ast::DataType::U32) {
+                        state.import_snippet(Box::new(arithmetic::u32::shift_right::ShiftRightU32))
+                    } else {
+                        state.import_snippet(Box::new(
+                            arithmetic::u64::shift_right_u64::ShiftRightU64,
+                        ))
+                    };
+
+                    let code = vec![lhs_expr_code, rhs_expr_code, vec![call(shr)]].concat();
+
+                    state.vstack.pop();
+                    state.vstack.pop();
+                    let addr = state.new_value_identifier("_binop_shr", &res_type);
+
+                    (addr, code)
+                }
 
                 ast::BinOp::Sub => {
                     let (_lhs_expr_addr, lhs_expr_code) =
@@ -1483,7 +1508,7 @@ fn compile_expr(
                     let (_, old_data_type) = state.vstack.pop().unwrap();
 
                     // sanity check
-                    assert_eq!(ast::DataType::U32, old_data_type);
+                    assert_eq!(ast::DataType::U64, old_data_type);
 
                     let addr = state.new_value_identifier("_as_u64", as_type);
 

--- a/src/tasm_code_generator.rs
+++ b/src/tasm_code_generator.rs
@@ -1272,11 +1272,14 @@ fn compile_expr(
                     let (_rhs_expr_addr, rhs_expr_code) =
                         compile_expr(rhs_expr, "_binop_rhs", &rhs_type, state);
 
-                    let shl = if matches!(lhs_expr.to_owned().get_type(), ast::DataType::U32) {
+                    let lhs_type = lhs_expr.get_type();
+                    let shl = if matches!(lhs_type, ast::DataType::U32) {
                         state.import_snippet(Box::new(arithmetic::u32::shift_left::ShiftLeftU32))
-                    } else {
+                    } else if matches!(lhs_type, ast::DataType::U64) {
                         state
                             .import_snippet(Box::new(arithmetic::u64::shift_left_u64::ShiftLeftU64))
+                    } else {
+                        panic!("Unsupported SHL of type {lhs_type}");
                     };
 
                     let code = vec![lhs_expr_code, rhs_expr_code, vec![call(shl)]].concat();
@@ -1295,12 +1298,15 @@ fn compile_expr(
                     let (_rhs_expr_addr, rhs_expr_code) =
                         compile_expr(rhs_expr, "_binop_rhs", &rhs_type, state);
 
-                    let shr = if matches!(lhs_expr.to_owned().get_type(), ast::DataType::U32) {
+                    let lhs_type = lhs_expr.get_type();
+                    let shr = if matches!(lhs_type, ast::DataType::U32) {
                         state.import_snippet(Box::new(arithmetic::u32::shift_right::ShiftRightU32))
-                    } else {
+                    } else if matches!(lhs_type, ast::DataType::U64) {
                         state.import_snippet(Box::new(
                             arithmetic::u64::shift_right_u64::ShiftRightU64,
                         ))
+                    } else {
+                        panic!("Unsupported SHL of type {lhs_type}");
                     };
 
                     let code = vec![lhs_expr_code, rhs_expr_code, vec![call(shr)]].concat();

--- a/src/tests/programs/arithmetic.rs
+++ b/src/tests/programs/arithmetic.rs
@@ -191,6 +191,45 @@ pub fn powers_of_two_with_bit_shifting() -> syn::ItemFn {
     })
 }
 
+#[allow(dead_code)]
+pub fn leftshift_u32_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn leftshift_u32(lhs: u32, rhs: u32) -> u32 {
+            let c: u32 = lhs << rhs;
+            return c;
+        }
+    })
+}
+
+#[allow(dead_code)]
+pub fn leftshift_u64_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn leftshift_u64(lhs: u64, rhs: u32) -> u64 {
+            let c: u64 = lhs << rhs;
+            return c;
+        }
+    })
+}
+
+#[allow(dead_code)]
+pub fn rightshift_u32_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn rightshift_u32(lhs: u32, rhs: u32) -> u32 {
+            let c: u32 = lhs >> rhs;
+            return c;
+        }
+    })
+}
+
+#[allow(dead_code)]
+pub fn rightshift_u64_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn rightshift_u64(lhs: u64, rhs: u32) -> u64 {
+            let c: u64 = lhs >> rhs;
+            return c;
+        }
+    })
+}
 #[cfg(test)]
 mod run_tests {
     use rand::{thread_rng, Rng};
@@ -294,6 +333,34 @@ mod run_tests {
             vec![u64_lit((1u64 << 40) + (1u64 << 60))],
         );
     }
+
+    #[test]
+    fn leftshift_u32_run_test() {
+        let input = vec![u32_lit(0b101010101010101u32), u32_lit(16u32)];
+        let expected_output = vec![u32_lit(1431633920)];
+        compare_prop_with_stack(&leftshift_u32_rast(), input, expected_output);
+    }
+
+    #[test]
+    fn leftshift_u64_run_test() {
+        let input = vec![u64_lit(0b10101010101010101010101010101u64), u32_lit(32u32)];
+        let expected_output = vec![u64_lit(1537228671377473536)];
+        compare_prop_with_stack(&leftshift_u64_rast(), input, expected_output);
+    }
+
+    #[test]
+    fn rightshift_u32_run_test() {
+        let input = vec![u32_lit(0b101010101010101u32), u32_lit(3u32)];
+        let expected_output = vec![u32_lit(2730)];
+        compare_prop_with_stack(&rightshift_u32_rast(), input, expected_output);
+    }
+
+    #[test]
+    fn rightshift_u64_run_test() {
+        let input = vec![u64_lit(0b10101010101010101010101010101u64), u32_lit(3u32)];
+        let expected_output = vec![u64_lit(44739242)];
+        compare_prop_with_stack(&rightshift_u64_rast(), input, expected_output);
+    }
 }
 
 #[cfg(test)]
@@ -364,5 +431,25 @@ mod compile_and_typecheck_tests {
     #[test]
     fn lt_u32_test() {
         graft_check_compile_prop(&lt_u32());
+    }
+
+    #[test]
+    fn leftshift_u32_test() {
+        graft_check_compile_prop(&leftshift_u32_rast());
+    }
+
+    #[test]
+    fn leftshift_u64_test() {
+        graft_check_compile_prop(&leftshift_u64_rast());
+    }
+
+    #[test]
+    fn rightshift_u32_test() {
+        graft_check_compile_prop(&rightshift_u32_rast());
+    }
+
+    #[test]
+    fn rightshift_u64_test() {
+        graft_check_compile_prop(&rightshift_u64_rast());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -726,13 +726,14 @@ fn derive_annotate_expr_type(
                 Shl => {
                     let lhs_type = derive_annotate_expr_type(lhs_expr, hint, state);
 
-                    let rhs_hint = Some(&ast::DataType::U32);
-                    let rhs_type = derive_annotate_expr_type(rhs_expr, rhs_hint, state);
-
                     assert!(
                         is_u32_based_type(&lhs_type),
                         "Cannot shift-left for type '{lhs_type}' (not u32-based)"
                     );
+
+                    let rhs_hint = Some(&ast::DataType::U32);
+                    let rhs_type = derive_annotate_expr_type(rhs_expr, rhs_hint, state);
+
                     assert_type_equals(&rhs_type, &ast::DataType::U32, "shl-rhs-expr");
                     *binop_type = Typing::KnownType(lhs_type.clone());
                     lhs_type
@@ -742,13 +743,14 @@ fn derive_annotate_expr_type(
                 Shr => {
                     let lhs_type = derive_annotate_expr_type(lhs_expr, hint, state);
 
-                    let rhs_hint = Some(&ast::DataType::U32);
-                    let rhs_type = derive_annotate_expr_type(rhs_expr, rhs_hint, state);
-
                     assert!(
                         is_u32_based_type(&lhs_type),
                         "Cannot shift-right for type '{lhs_type}' (not u32-based)"
                     );
+
+                    let rhs_hint = Some(&ast::DataType::U32);
+                    let rhs_type = derive_annotate_expr_type(rhs_expr, rhs_hint, state);
+
                     assert_type_equals(&rhs_type, &ast::DataType::U32, "shr-rhs-expr");
                     *binop_type = Typing::KnownType(lhs_type.clone());
                     lhs_type


### PR DESCRIPTION
Rewrite `Shl` in terms of the new `shift_*` snippets and implement `Shr` symmetrically

Rearranged some assertions and fixed a bug---both related to `BinOp`s.

Wrote one unittest for each of `u32<<u32`, `u64<<u32`, `u32>>u32`, `u64>>u32`.

`make all` succeeds
`cargo test` succeeds
`clippy --all-targets` succeeds