### PR TITLE
Implement `ast::BinOp::Rem`

### DIFF
--- a/src/tasm_code_generator.rs
+++ b/src/tasm_code_generator.rs
@@ -1467,8 +1467,12 @@ fn compile_expr(
 
                             (
                                 addr,
-                                vec![lhs_expr_code, rhs_expr_code, vec![swap(1), div(), pop()]]
-                                    .concat(),
+                                vec![
+                                    lhs_expr_code,
+                                    rhs_expr_code,
+                                    vec![swap(1), div(), swap(1), pop()],
+                                ]
+                                .concat(),
                             )
                         }
                         U64 => {

--- a/src/tasm_code_generator.rs
+++ b/src/tasm_code_generator.rs
@@ -1468,9 +1468,9 @@ fn compile_expr(
                             (
                                 addr,
                                 vec![
-                                    lhs_expr_code,
                                     rhs_expr_code,
-                                    vec![swap(1), div(), swap(1), pop()],
+                                    lhs_expr_code,
+                                    vec![ div(), swap(1), pop()],
                                 ]
                                 .concat(),
                             )
@@ -1481,17 +1481,20 @@ fn compile_expr(
                             if !matches!(rhs_expr_owned, ast::Expr::Lit(ast::ExprLit::U64(2))) {
                                 panic!("Unsupported division with denominator: {rhs_expr_owned:#?}")
                             }
-
                             let (_lhs_expr_addr, lhs_expr_code) =
                                 compile_expr(lhs_expr, "_binop_lhs", &lhs_type, state);
-                            let div2 =
-                                state.import_snippet(Box::new(arithmetic::u64::div2_u64::Div2U64));
+
+                            let (_rhs_expr_addr, rhs_expr_code) =
+                                compile_expr(rhs_expr, "_binop_rhs", &rhs_type, state);
 
                             // Pop the numerator that was divided by two
                             state.vstack.pop();
+                            state.vstack.pop();
                             let addr = state.new_value_identifier("_binop_rem", &res_type);
 
-                            (addr, vec![lhs_expr_code, vec![call(div2)]].concat())
+                            // 0, 17, 0, 2
+                            //(addr, vec![lhs_expr_code, rhs_expr_code, vec![swap(1), pop(), div(), swap(1), pop(), swap(1)]].concat())
+                            (addr, vec![lhs_expr_code, rhs_expr_code, vec![swap(3),pop(),pop(),div(),swap(1),pop(),dup(2),swap(1)]].concat())
                         }
                         _ => panic!("Unsupported instruction `rem` for type {res_type}.  Only `u32` and `u64` are supported"),
                     }

--- a/src/tasm_code_generator.rs
+++ b/src/tasm_code_generator.rs
@@ -1463,7 +1463,7 @@ fn compile_expr(
                             // Pop numerator and denominator
                             state.vstack.pop();
                             state.vstack.pop();
-                            let addr = state.new_value_identifier("_binop_div", &res_type);
+                            let addr = state.new_value_identifier("_binop_rem", &res_type);
 
                             (
                                 addr,
@@ -1489,7 +1489,7 @@ fn compile_expr(
 
                             // Pop the numerator that was divided by two
                             state.vstack.pop();
-                            let addr = state.new_value_identifier("_binop_div", &res_type);
+                            let addr = state.new_value_identifier("_binop_rem", &res_type);
 
                             (addr, vec![lhs_expr_code, vec![call(div2)]].concat())
                         }

--- a/src/tasm_code_generator.rs
+++ b/src/tasm_code_generator.rs
@@ -1493,65 +1493,7 @@ fn compile_expr(
 
                             (addr, vec![lhs_expr_code, vec![call(div2)]].concat())
                         }
-                        BFE => {
-                            let (_lhs_expr_addr, lhs_expr_code) =
-                                compile_expr(lhs_expr, "_binop_lhs", &lhs_type, state);
-                            let (_rhs_expr_addr, rhs_expr_code) =
-                                compile_expr(rhs_expr, "_binop_rhs", &rhs_type, state);
-
-                            // div num
-                            let bfe_div_code = vec![
-                                swap(1),  // _ num div
-                                invert(), // _ num (1/div)
-                                mul(),    // _ num·(1/div), or (num/div)
-                            ];
-
-                            // Pop numerator and denominator
-                            state.vstack.pop();
-                            state.vstack.pop();
-                            let addr = state.new_value_identifier("_binop_div", &res_type);
-
-                            (
-                                addr,
-                                vec![lhs_expr_code, rhs_expr_code, bfe_div_code].concat(),
-                            )
-                        }
-                        XFE => {
-                            let (_lhs_expr_addr, lhs_expr_code) =
-                                compile_expr(lhs_expr, "_binop_lhs", &lhs_type, state);
-                            let (_rhs_expr_addr, rhs_expr_code) =
-                                compile_expr(rhs_expr, "_binop_rhs", &rhs_type, state);
-
-                            // div_2 div_1 div_0 num_2 num_1 num_0
-                            let xfe_div_code = vec![
-                                swap(5),   // num_0 div_1 div_0 num_2 num_1 div_2
-                                swap(2),   // num_0 div_1 div_0 div_2 num_1 num_2
-                                swap(5),   // num_2 div_1 div_0 div_2 num_1 num_0
-                                swap(4),   // num_2 num_0 div_0 div_2 num_1 div_1
-                                swap(1),   // num_2 num_0 div_0 div_2 div_1 num_1
-                                swap(4),   // num_2 num_1 div_0 div_2 div_1 num_0
-                                swap(3),   // num_2 num_1 num_0 div_2 div_1 div_0
-                                xinvert(), // num_2 num_1 num_0 (1/div)_2 (1/div)_1 (1/div)_0
-                                xxmul(),   // num_2 num_1 num_0 (num/div)_2 (num/div)_1 (num/div)_0
-                                swap(3),   // num_2 num_1 (num/div)_0 (num/div)_2 (num/div)_1 num_0
-                                pop(),     // num_2 num_1 (num/div)_0 (num/div)_2 (num/div)_1
-                                swap(3),   // num_2 (num/div)_1 (num/div)_0 (num/div)_2 num_1
-                                pop(),     // num_2 (num/div)_1 (num/div)_0 (num/div)_2
-                                swap(3),   // (num/div)_2 (num/div)_1 (num/div)_0 num_2
-                                pop(),     // (num/div)_2 (num/div)_1 (num/div)_0
-                            ];
-
-                            // Pop numerator and denominator
-                            state.vstack.pop();
-                            state.vstack.pop();
-                            let addr = state.new_value_identifier("_binop_div", &res_type);
-
-                            (
-                                addr,
-                                vec![lhs_expr_code, rhs_expr_code, xfe_div_code].concat(),
-                            )
-                        }
-                        _ => panic!("Unsupported div for type {res_type}"),
+                        _ => panic!("Unsupported instruction `rem` for type {res_type}.  Only `u32` and `u64` are supported"),
                     }
                 }
 

--- a/src/tasm_code_generator.rs
+++ b/src/tasm_code_generator.rs
@@ -1451,7 +1451,7 @@ fn compile_expr(
 
                 ast::BinOp::Rem => {
                     use ast::DataType::*;
-                    match res_type {
+                    match result_type {
                         U32 => {
                             // TODO: Consider evaluating in opposite order to save a clock-cycle by removing `swap1`
                             // below. This would change the "left-to-right" convention though.
@@ -1463,17 +1463,12 @@ fn compile_expr(
                             // Pop numerator and denominator
                             state.vstack.pop();
                             state.vstack.pop();
-                            let addr = state.new_value_identifier("_binop_rem", &res_type);
 
-                            (
-                                addr,
-                                vec![
-                                    lhs_expr_code,
-                                    rhs_expr_code,
-                                    vec![swap(1), div(), swap(1), pop()],
-                                ]
-                                .concat(),
-                            )
+                            vec![
+                                lhs_expr_code,
+                                rhs_expr_code,
+                                vec![swap(1), div(), swap(1), pop()],
+                            ].concat()
                         }
                         U64 => {
                             // For now we can only divide u64s by 2.
@@ -1490,13 +1485,10 @@ fn compile_expr(
                             // Pop the numerator that was divided by two
                             state.vstack.pop();
                             state.vstack.pop();
-                            let addr = state.new_value_identifier("_binop_rem", &res_type);
 
-                            // This ignores the upper u32 part of the numerator since divisor is always 2.
-                            // Thus, the result only depends on LSB.
-                            (addr, vec![lhs_expr_code, rhs_expr_code, vec![swap(1),swap(2),div(),swap(2),pop(),pop()]].concat())
+                            vec![lhs_expr_code, rhs_expr_code, vec![swap(1),swap(2),div(),swap(2),pop(),pop()]].concat()
                         }
-                        _ => panic!("Unsupported instruction `rem` for type {res_type}.  Only `u32` and `u64` are supported"),
+                        _ => panic!("Unsupported instruction `rem` for type {result_type}.  Only `u32` and `u64` are supported"),
                     }
                 }
 

--- a/src/tasm_code_generator.rs
+++ b/src/tasm_code_generator.rs
@@ -1468,9 +1468,9 @@ fn compile_expr(
                             (
                                 addr,
                                 vec![
-                                    rhs_expr_code,
                                     lhs_expr_code,
-                                    vec![ div(), swap(1), pop()],
+                                    rhs_expr_code,
+                                    vec![swap(1), div(), swap(1), pop()],
                                 ]
                                 .concat(),
                             )
@@ -1492,9 +1492,9 @@ fn compile_expr(
                             state.vstack.pop();
                             let addr = state.new_value_identifier("_binop_rem", &res_type);
 
-                            // 0, 17, 0, 2
-                            //(addr, vec![lhs_expr_code, rhs_expr_code, vec![swap(1), pop(), div(), swap(1), pop(), swap(1)]].concat())
-                            (addr, vec![lhs_expr_code, rhs_expr_code, vec![swap(3),pop(),pop(),div(),swap(1),pop(),dup(2),swap(1)]].concat())
+                            // This ignores the upper u32 part of the numerator since divisor is always 2.
+                            // Thus, the result only depends on LSB.
+                            (addr, vec![lhs_expr_code, rhs_expr_code, vec![swap(1),swap(2),div(),swap(2),pop(),pop()]].concat())
                         }
                         _ => panic!("Unsupported instruction `rem` for type {res_type}.  Only `u32` and `u64` are supported"),
                     }

--- a/src/tests/programs/arithmetic/bfe.rs
+++ b/src/tests/programs/arithmetic/bfe.rs
@@ -49,14 +49,6 @@ pub fn div_bfe_rast() -> syn::ItemFn {
     })
 }
 
-#[allow(dead_code)]
-pub fn rem_bfe_rast() -> syn::ItemFn {
-    item_fn(parse_quote! {
-        fn rem_bfe(rhs: BFieldElement, lhs: BFieldElement) ->  BFieldElement {
-            return rhs % lhs;
-        }
-    })
-}
 #[cfg(test)]
 mod compile_and_typecheck_tests {
     use super::*;

--- a/src/tests/programs/arithmetic/bfe.rs
+++ b/src/tests/programs/arithmetic/bfe.rs
@@ -40,6 +40,23 @@ fn cast_from_bool_rast() -> syn::ItemFn {
     })
 }
 
+#[allow(dead_code)]
+pub fn div_bfe_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn div_bfe(rhs: BFieldElement, lhs: BFieldElement) ->  BFieldElement {
+            return rhs / lhs;
+        }
+    })
+}
+
+#[allow(dead_code)]
+pub fn rem_bfe_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn rem_bfe(rhs: BFieldElement, lhs: BFieldElement) ->  BFieldElement {
+            return rhs % lhs;
+        }
+    })
+}
 #[cfg(test)]
 mod compile_and_typecheck_tests {
     use super::*;
@@ -59,15 +76,6 @@ mod run_tests {
     use crate::tests::shared_test::*;
 
     #[test]
-    fn instantiate_bfe_test() {
-        compare_prop_with_stack(
-            &instantiate_bfe_with_literal(),
-            vec![],
-            vec![bfe_lit(400u64.into()), bfe_lit(500u64.into())],
-        );
-    }
-
-    #[test]
     fn add_bfe_test() {
         compare_prop_with_stack(
             &add_bfe_rast(),
@@ -85,20 +93,6 @@ mod run_tests {
                 bfe_lit(10_000_000_000u64.into()),
             ],
             vec![bfe_lit(7766279652927078395u64.into())],
-        );
-    }
-
-    #[test]
-    fn cast_from_bool_test() {
-        compare_prop_with_stack(
-            &cast_from_bool_rast(),
-            vec![bool_lit(false)],
-            vec![bfe_lit(0u64.into())],
-        );
-        compare_prop_with_stack(
-            &cast_from_bool_rast(),
-            vec![bool_lit(true)],
-            vec![bfe_lit(1u64.into())],
         );
     }
 }

--- a/src/tests/programs/arithmetic/bfe.rs
+++ b/src/tests/programs/arithmetic/bfe.rs
@@ -68,6 +68,15 @@ mod run_tests {
     use crate::tests::shared_test::*;
 
     #[test]
+    fn instantiate_bfe_test() {
+        compare_prop_with_stack(
+            &instantiate_bfe_with_literal(),
+            vec![],
+            vec![bfe_lit(400u64.into()), bfe_lit(500u64.into())],
+        );
+    }
+
+    #[test]
     fn add_bfe_test() {
         compare_prop_with_stack(
             &add_bfe_rast(),
@@ -85,6 +94,20 @@ mod run_tests {
                 bfe_lit(10_000_000_000u64.into()),
             ],
             vec![bfe_lit(7766279652927078395u64.into())],
+        );
+    }
+
+    #[test]
+    fn cast_from_bool_test() {
+        compare_prop_with_stack(
+            &cast_from_bool_rast(),
+            vec![bool_lit(false)],
+            vec![bfe_lit(0u64.into())],
+        );
+        compare_prop_with_stack(
+            &cast_from_bool_rast(),
+            vec![bool_lit(true)],
+            vec![bfe_lit(1u64.into())],
         );
     }
 }

--- a/src/tests/programs/arithmetic/u32.rs
+++ b/src/tests/programs/arithmetic/u32.rs
@@ -62,6 +62,24 @@ pub fn mul_u32_rast() -> syn::ItemFn {
 }
 
 #[allow(dead_code)]
+pub fn div_u32_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn div_u32(rhs: u32, lhs: u32) -> u32 {
+            return rhs / lhs;
+        }
+    })
+}
+
+#[allow(dead_code)]
+pub fn rem_u32_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn rem_u32(rhs: u32, lhs: u32) -> u32 {
+            return rhs % lhs;
+        }
+    })
+}
+
+#[allow(dead_code)]
 pub fn bitwise_and_u32_rast() -> syn::ItemFn {
     item_fn(parse_quote! {
         fn bitwise_and_u32(lhs: u32, rhs: u32) -> u32 {

--- a/src/tests/programs/arithmetic/u32.rs
+++ b/src/tests/programs/arithmetic/u32.rs
@@ -252,17 +252,17 @@ mod compile_and_typecheck_tests {
 
     #[test]
     fn mul_u32_rast_test() {
-        graft_check_compile_prop(&&mul_u32_rast());
+        graft_check_compile_prop(&mul_u32_rast());
     }
 
     #[test]
     fn div_u32_rast_test() {
-        graft_check_compile_prop(&&div_u32_rast());
+        graft_check_compile_prop(&div_u32_rast());
     }
 
     #[test]
     fn rem_u32_rast_test() {
-        graft_check_compile_prop(&&rem_u32_rast());
+        graft_check_compile_prop(&rem_u32_rast());
     }
 
     #[test]

--- a/src/tests/programs/arithmetic/u32.rs
+++ b/src/tests/programs/arithmetic/u32.rs
@@ -237,6 +237,21 @@ mod compile_and_typecheck_tests {
     }
 
     #[test]
+    fn mul_u32_rast_test() {
+        graft_check_compile_prop(&&mul_u32_rast());
+    }
+
+    #[test]
+    fn div_u32_rast_test() {
+        graft_check_compile_prop(&&div_u32_rast());
+    }
+
+    #[test]
+    fn rem_u32_rast_test() {
+        graft_check_compile_prop(&&rem_u32_rast());
+    }
+
+    #[test]
     fn bitwise_and_u32_test() {
         graft_check_compile_prop(&bitwise_and_u32_rast());
     }

--- a/src/tests/programs/arithmetic/u32.rs
+++ b/src/tests/programs/arithmetic/u32.rs
@@ -176,6 +176,20 @@ mod run_tests {
     }
 
     #[test]
+    fn div_u32_run_test() {
+        let input_args_1 = vec![u32_lit(56), u32_lit(7)];
+        let expected_outputs_1 = vec![u32_lit(8)];
+        compare_prop_with_stack(&div_u32_rast(), input_args_1, expected_outputs_1);
+    }
+
+    #[test]
+    fn rem_u32_run_test() {
+        let input_args_1 = vec![u32_lit(17), u32_lit(6)];
+        let expected_outputs_1 = vec![u32_lit(5)];
+        compare_prop_with_stack(&rem_u32_rast(), input_args_1, expected_outputs_1);
+    }
+
+    #[test]
     fn lt_u32_test() {
         compare_prop_with_stack(&lt_u32(), vec![], vec![bool_lit(true)]);
     }

--- a/src/tests/programs/arithmetic/u64.rs
+++ b/src/tests/programs/arithmetic/u64.rs
@@ -44,6 +44,24 @@ pub fn mul_u64_rast() -> syn::ItemFn {
 }
 
 #[allow(dead_code)]
+pub fn div_u64_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn div_u64(rhs: u64, lhs: u64) -> u64 {
+            return rhs / lhs;
+        }
+    })
+}
+
+#[allow(dead_code)]
+pub fn rem_u64_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn rem_u64(rhs: u64, lhs: u64) -> u64 {
+            return rhs % lhs;
+        }
+    })
+}
+
+#[allow(dead_code)]
 pub fn bitwise_and_u64_rast() -> syn::ItemFn {
     item_fn(parse_quote! {
         fn bitwise_and_u64(lhs: u64, rhs: u64) -> u64 {

--- a/src/tests/programs/arithmetic/u64.rs
+++ b/src/tests/programs/arithmetic/u64.rs
@@ -157,6 +157,20 @@ mod run_tests {
     }
 
     #[test]
+    fn div_u64_run_test() {
+        let input_args_1 = vec![u64_lit(56), u64_lit(7)];
+        let expected_outputs_1 = vec![u64_lit(8)];
+        compare_prop_with_stack(&div_u64_rast(), input_args_1, expected_outputs_1);
+    }
+
+    #[test]
+    fn rem_u64_run_test() {
+        let input_args_1 = vec![u64_lit(17), u64_lit(6)];
+        let expected_outputs_1 = vec![u64_lit(5)];
+        compare_prop_with_stack(&rem_u64_rast(), input_args_1, expected_outputs_1);
+    }
+
+    #[test]
     fn leftshift_u64_run_test() {
         let input = vec![u64_lit(0b10101010101010101010101010101u64), u32_lit(32u32)];
         let expected_output = vec![u64_lit(1537228671377473536)];

--- a/src/tests/programs/arithmetic/u64.rs
+++ b/src/tests/programs/arithmetic/u64.rs
@@ -46,8 +46,8 @@ pub fn mul_u64_rast() -> syn::ItemFn {
 #[allow(dead_code)]
 pub fn div_u64_rast() -> syn::ItemFn {
     item_fn(parse_quote! {
-        fn div_u64(rhs: u64, lhs: u64) -> u64 {
-            return rhs / lhs;
+        fn div_u64(rhs: u64, _lhs: u64) -> u64 {
+            return rhs / 2u64;
         }
     })
 }
@@ -55,8 +55,8 @@ pub fn div_u64_rast() -> syn::ItemFn {
 #[allow(dead_code)]
 pub fn rem_u64_rast() -> syn::ItemFn {
     item_fn(parse_quote! {
-        fn rem_u64(rhs: u64, lhs: u64) -> u64 {
-            return rhs % lhs;
+        fn rem_u64(rhs: u64, _lhs: u64) -> u64 {
+            return rhs % 2u64;
         }
     })
 }
@@ -158,15 +158,15 @@ mod run_tests {
 
     #[test]
     fn div_u64_run_test() {
-        let input_args_1 = vec![u64_lit(56), u64_lit(7)];
-        let expected_outputs_1 = vec![u64_lit(8)];
+        let input_args_1 = vec![u64_lit(56), u64_lit(2)];
+        let expected_outputs_1 = vec![u64_lit(28)];
         compare_prop_with_stack(&div_u64_rast(), input_args_1, expected_outputs_1);
     }
 
     #[test]
     fn rem_u64_run_test() {
-        let input_args_1 = vec![u64_lit(17), u64_lit(6)];
-        let expected_outputs_1 = vec![u64_lit(5)];
+        let input_args_1 = vec![u64_lit(17), u64_lit(2)];
+        let expected_outputs_1 = vec![u64_lit(1)];
         compare_prop_with_stack(&rem_u64_rast(), input_args_1, expected_outputs_1);
     }
 

--- a/src/tests/programs/arithmetic/xfe.rs
+++ b/src/tests/programs/arithmetic/xfe.rs
@@ -12,6 +12,24 @@ pub fn add_xfe_rast() -> syn::ItemFn {
     })
 }
 
+#[allow(dead_code)]
+pub fn div_xfe_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn div_xfe(rhs: XFieldElement, lhs: XFieldElement) ->  XFieldElement {
+            return rhs / lhs;
+        }
+    })
+}
+
+#[allow(dead_code)]
+pub fn rem_xfe_rast() -> syn::ItemFn {
+    item_fn(parse_quote! {
+        fn rem_xfe(rhs: XFieldElement, lhs: XFieldElement) ->  XFieldElement {
+            return rhs % lhs;
+        }
+    })
+}
+
 #[cfg(test)]
 mod compile_and_typecheck_tests {
     use crate::tests::shared_test::graft_check_compile_prop;

--- a/src/tests/programs/arithmetic/xfe.rs
+++ b/src/tests/programs/arithmetic/xfe.rs
@@ -21,15 +21,6 @@ pub fn div_xfe_rast() -> syn::ItemFn {
     })
 }
 
-#[allow(dead_code)]
-pub fn rem_xfe_rast() -> syn::ItemFn {
-    item_fn(parse_quote! {
-        fn rem_xfe(rhs: XFieldElement, lhs: XFieldElement) ->  XFieldElement {
-            return rhs % lhs;
-        }
-    })
-}
-
 #[cfg(test)]
 mod compile_and_typecheck_tests {
     use crate::tests::shared_test::graft_check_compile_prop;


### PR DESCRIPTION
This is inspired by the `ast::BinOp::Div`, and adds some previously missing tests for `Div` and `Mul` as well.