### PR TITLE
Thv/option types

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -570,7 +570,6 @@ impl Identifier<Typing> {
             Identifier::Index(_, _, t) => t,
             Identifier::Field(_, _, t) => t,
         };
-        // matches!(t, Typing::KnownType(_))
         match t {
             Typing::UnknownType => None,
             Typing::KnownType(resolved_type) => Some(resolved_type.to_owned()),

--- a/src/composite_types.rs
+++ b/src/composite_types.rs
@@ -254,6 +254,23 @@ impl CompositeTypes {
     }
 
     /********** Type Checking **********/
+    pub(crate) fn prelude_variant_match(
+        &self,
+        variant_name: &str,
+        expected_type: &ast_types::DataType,
+    ) -> Option<EnumType> {
+        let expected_type = expected_type.as_enum_type();
+        let preludes = self.preludes();
+        let mut ret = None;
+        for prelude in preludes {
+            if prelude.has_variant_of_name(variant_name) && prelude == expected_type {
+                ret = Some(prelude);
+            }
+        }
+
+        ret
+    }
+
     pub(crate) fn methods_mut(&mut self) -> std::vec::IntoIter<&mut ast::Method<Typing>> {
         self.composite_types
             .iter_mut()
@@ -388,7 +405,7 @@ impl CompositeTypes {
     /// Return all enums that are included in `prelude`, meaning that
     /// the programmer only has to specify the variant name, not the type.
     /// E.g.: `Ok(5)` instead of `Return::Ok(5)`.
-    fn get_preludes(&self) -> Vec<EnumType> {
+    fn preludes(&self) -> Vec<EnumType> {
         let mut ret = vec![];
         for dtype in self.composite_types.iter() {
             if dtype.composite_type.is_prelude() {
@@ -420,7 +437,7 @@ impl CompositeTypes {
         let split_name = name.split("::").collect_vec();
 
         // Is this an enum constructor for a type in `prelude`? E.g. `Ok(...)`.
-        for prelude in self.get_preludes() {
+        for prelude in self.preludes() {
             if prelude.has_variant_of_name(split_name[0]) {
                 let variant_name = split_name[0];
                 if prelude

--- a/src/libraries/core.rs
+++ b/src/libraries/core.rs
@@ -10,6 +10,7 @@ use crate::libraries::{Annotation, Library};
 use crate::tasm_code_generator::CompilerState;
 use crate::type_checker::CheckState;
 
+pub mod option_type;
 pub mod result_type;
 
 /// Everything that lives in the Rust `core` module

--- a/src/libraries/core/option_type.rs
+++ b/src/libraries/core/option_type.rs
@@ -1,0 +1,139 @@
+use triton_vm::triton_asm;
+
+use crate::ast::{self, FnSignature};
+use crate::ast_types::DataType;
+use crate::ast_types::{self, AbstractArgument, AbstractValueArg};
+use crate::tasm_code_generator;
+use crate::type_checker::Typing;
+
+pub(crate) fn option_type(payload_type: DataType) -> crate::composite_types::TypeContext {
+    let enum_type = ast_types::EnumType {
+        is_copy: payload_type.is_copy(),
+        name: "Option".to_owned(),
+        variants: vec![
+            (
+                "None".to_owned(),
+                DataType::Tuple(vec![DataType::unit()].into()),
+            ),
+            ("Some".to_owned(), payload_type.clone()),
+        ],
+        is_prelude: true,
+        type_parameter: Some(payload_type.clone()),
+    };
+    let is_some_method = option_is_some_method(&enum_type);
+    let is_none_method = option_is_none_method(&enum_type);
+    let unwrap_method = option_unwrap_method(&enum_type);
+
+    crate::composite_types::TypeContext {
+        composite_type: enum_type.into(),
+        methods: vec![is_some_method, is_none_method, unwrap_method],
+        associated_functions: vec![],
+    }
+}
+
+fn option_unwrap_method(enum_type: &ast_types::EnumType) -> ast::Method<Typing> {
+    let method_signature = FnSignature {
+        name: "unwrap".to_owned(),
+        args: vec![AbstractArgument::ValueArgument(AbstractValueArg {
+            name: "self".to_owned(),
+            data_type: enum_type.into(),
+            mutable: false,
+        })],
+        output: enum_type.variant_data_type("Some"),
+        arg_evaluation_order: Default::default(),
+    };
+
+    ast::Method {
+        body: ast::RoutineBody::<Typing>::Instructions(triton_asm!(
+            // _ [some_type] discriminant
+            assert // _ [some_type]
+        )),
+        signature: method_signature,
+    }
+}
+
+fn option_is_none_method(enum_type: &ast_types::EnumType) -> ast::Method<Typing> {
+    let stack_size = enum_type.stack_size();
+    let swap_to_bottom = match stack_size {
+        0 => unreachable!(),
+        1 => triton_asm!(),
+        2..=16 => triton_asm!(swap { stack_size - 1 }),
+        _ => panic!("Can't handle this yet"), // This should work with spilling
+    };
+    let remove_data = match stack_size {
+        0 => unreachable!(),
+        1 => triton_asm!(pop 1),
+        2..=16 => tasm_code_generator::pop_n(stack_size - 1),
+        _ => panic!("Can't handle this yet"),
+    };
+    let argument_type = DataType::Reference(Box::new(enum_type.into()));
+    let method_signature = FnSignature {
+        name: "is_err".to_owned(),
+        args: vec![AbstractArgument::ValueArgument(AbstractValueArg {
+            name: "self".to_owned(),
+            data_type: argument_type,
+            mutable: false,
+        })],
+        output: DataType::Bool,
+        arg_evaluation_order: Default::default(),
+    };
+
+    ast::Method {
+        body: ast::RoutineBody::<Typing>::Instructions(triton_asm!(
+                // _ [ok_type] discriminant
+                {&swap_to_bottom}
+                // _ discriminant [ok_type']
+
+                {&remove_data}
+                // _ discriminant
+
+                push 0
+                eq
+                // _ (discriminant == 0 :== variant is 'None')
+        )),
+        signature: method_signature,
+    }
+}
+
+fn option_is_some_method(enum_type: &ast_types::EnumType) -> ast::Method<Typing> {
+    let stack_size = enum_type.stack_size();
+    let swap_to_bottom = match stack_size {
+        0 => unreachable!(),
+        1 => triton_asm!(),
+        2..=16 => triton_asm!(swap { stack_size - 1 }),
+        _ => panic!("Can't handle this yet"), // This should work with spilling
+    };
+    let remove_data = match stack_size {
+        0 => unreachable!(),
+        1 => triton_asm!(pop 1),
+        2..=16 => tasm_code_generator::pop_n(stack_size - 1),
+        _ => panic!("Can't handle this yet"),
+    };
+    let argument_type = DataType::Reference(Box::new(enum_type.into()));
+    let method_signature = FnSignature {
+        name: "is_some".to_owned(),
+        args: vec![AbstractArgument::ValueArgument(AbstractValueArg {
+            name: "self".to_owned(),
+            data_type: argument_type,
+            mutable: false,
+        })],
+        output: DataType::Bool,
+        arg_evaluation_order: Default::default(),
+    };
+
+    ast::Method {
+        body: ast::RoutineBody::<Typing>::Instructions(triton_asm!(
+                // _ [ok_type] discriminant
+                {&swap_to_bottom}
+                // _ discriminant [ok_type']
+
+                {&remove_data}
+                // _ discriminant
+
+                push 1
+                eq
+                // _ (discriminant == 1 :== variant is 'Some')
+        )),
+        signature: method_signature,
+    }
+}

--- a/src/libraries/core/option_type.rs
+++ b/src/libraries/core/option_type.rs
@@ -11,10 +11,7 @@ pub(crate) fn option_type(payload_type: DataType) -> crate::composite_types::Typ
         is_copy: payload_type.is_copy(),
         name: "Option".to_owned(),
         variants: vec![
-            (
-                "None".to_owned(),
-                DataType::Tuple(vec![DataType::unit()].into()),
-            ),
+            ("None".to_owned(), DataType::unit()),
             ("Some".to_owned(), payload_type.clone()),
         ],
         is_prelude: true,
@@ -68,7 +65,7 @@ fn option_is_none_method(enum_type: &ast_types::EnumType) -> ast::Method<Typing>
     };
     let argument_type = DataType::Reference(Box::new(enum_type.into()));
     let method_signature = FnSignature {
-        name: "is_err".to_owned(),
+        name: "is_none".to_owned(),
         args: vec![AbstractArgument::ValueArgument(AbstractValueArg {
             name: "self".to_owned(),
             data_type: argument_type,

--- a/src/tests_and_benchmarks/ozk/programs.rs
+++ b/src/tests_and_benchmarks/ozk/programs.rs
@@ -2,6 +2,7 @@ mod arithmetic;
 mod arrays;
 mod boxed;
 mod enums;
+mod option_types;
 mod other;
 mod project_euler;
 pub mod recufier;

--- a/src/tests_and_benchmarks/ozk/programs/option_types.rs
+++ b/src/tests_and_benchmarks/ozk/programs/option_types.rs
@@ -1,1 +1,1 @@
-mod simple_is_some;
+mod basic;

--- a/src/tests_and_benchmarks/ozk/programs/option_types.rs
+++ b/src/tests_and_benchmarks/ozk/programs/option_types.rs
@@ -1,1 +1,2 @@
 mod basic;
+mod mutable_values;

--- a/src/tests_and_benchmarks/ozk/programs/option_types.rs
+++ b/src/tests_and_benchmarks/ozk/programs/option_types.rs
@@ -1,0 +1,1 @@
+mod simple_is_some;

--- a/src/tests_and_benchmarks/ozk/programs/option_types/basic.rs
+++ b/src/tests_and_benchmarks/ozk/programs/option_types/basic.rs
@@ -1,9 +1,10 @@
-use triton_vm::BFieldElement;
+use triton_vm::{BFieldElement, Digest};
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use crate::tests_and_benchmarks::ozk::rust_shadows as tasm;
 
 #[allow(clippy::unnecessary_literal_unwrap)]
+#[allow(clippy::assertions_on_constants)]
 fn main() {
     let bfe: BFieldElement = tasm::tasm_io_read_stdin___bfe();
     let some_bfe: Option<BFieldElement> = Some(bfe);
@@ -17,6 +18,62 @@ fn main() {
 
     let none_xfe: Option<XFieldElement> = None;
     assert!(none_xfe.is_none());
+    let none_digest: Option<Digest> = None;
+    assert!(none_digest.is_none());
+    let none_bfe: Option<BFieldElement> = None;
+    assert!(none_bfe.is_none());
+
+    match some_xfe {
+        Some(inner) => {
+            tasm::tasm_io_write_to_stdout___xfe(inner);
+        }
+        None => {
+            assert!(false);
+        }
+    };
+
+    match some_bfe {
+        Some(inner) => {
+            tasm::tasm_io_write_to_stdout___bfe(inner);
+        }
+        None => {
+            assert!(false);
+        }
+    };
+    match some_bfe {
+        Some(inner) => {
+            tasm::tasm_io_write_to_stdout___bfe(inner);
+        }
+        _ => {
+            assert!(false);
+        }
+    };
+
+    match none_xfe {
+        Some(_) => {
+            assert!(false);
+        }
+        None => {
+            tasm::tasm_io_write_to_stdout___u32(100);
+        }
+    };
+    match none_xfe {
+        Some(_) => {
+            assert!(false);
+        }
+        _ => {
+            tasm::tasm_io_write_to_stdout___u32(100);
+        }
+    };
+
+    match none_digest {
+        Some(_) => {
+            assert!(false);
+        }
+        None => {
+            tasm::tasm_io_write_to_stdout___u32(101);
+        }
+    };
 
     return;
 }
@@ -41,7 +98,7 @@ mod test {
             rust_shadows::wrap_main_with_io(&main)(stdin.clone(), non_determinism.clone());
         let test_program = ozk_parsing::compile_for_test(
             "option_types",
-            "simple_is_some",
+            "basic",
             "main",
             crate::ast_types::ListType::Unsafe,
         );

--- a/src/tests_and_benchmarks/ozk/programs/option_types/mutable_values.rs
+++ b/src/tests_and_benchmarks/ozk/programs/option_types/mutable_values.rs
@@ -1,0 +1,82 @@
+use triton_vm::Digest;
+use twenty_first::shared_math::x_field_element::XFieldElement;
+
+use crate::tests_and_benchmarks::ozk::rust_shadows as tasm;
+
+#[allow(clippy::unnecessary_literal_unwrap)]
+#[allow(clippy::assertions_on_constants)]
+#[allow(unused_assignments)]
+fn main() {
+    let mut none_value: Option<u64> = None;
+    assert!(none_value.is_none());
+    none_value = None;
+    assert!(none_value.is_none());
+
+    let mut none_to_some_value: Option<u64> = None;
+    assert!(none_to_some_value.is_none());
+    none_to_some_value = Some((1u64 << 40) + 100);
+    assert!(none_to_some_value.is_some());
+
+    let mut some_to_none_value: Option<XFieldElement> = Some(tasm::tasm_io_read_stdin___xfe());
+    tasm::tasm_io_write_to_stdout___xfe(some_to_none_value.unwrap());
+    assert!(some_to_none_value.is_some());
+    some_to_none_value = None;
+    assert!(some_to_none_value.is_none());
+
+    let mut some_value: Option<Digest> = Some(tasm::tasm_io_read_stdin___digest());
+    tasm::tasm_io_write_to_stdout___digest(some_value.unwrap());
+    assert!(some_value.is_some());
+    some_value = Some(tasm::tasm_io_read_stdin___digest());
+    tasm::tasm_io_write_to_stdout___digest(some_value.unwrap());
+    assert!(some_value.is_some());
+
+    // Match statement to ensure stack size is tracked correctly
+    match none_to_some_value {
+        None => {
+            assert!(false);
+        }
+        Some(payload) => {
+            tasm::tasm_io_write_to_stdout___u64(payload);
+        }
+    };
+
+    return;
+}
+
+mod test {
+    use std::collections::HashMap;
+    use std::default::Default;
+
+    use rand::random;
+    use triton_vm::NonDeterminism;
+
+    use crate::tests_and_benchmarks::ozk::{ozk_parsing, rust_shadows};
+    use crate::tests_and_benchmarks::test_helpers::shared_test::*;
+
+    use super::*;
+
+    #[test]
+    fn mutable_values_test() {
+        let stdin = vec![random(); 13];
+        let non_determinism = NonDeterminism::default();
+        let native_output =
+            rust_shadows::wrap_main_with_io(&main)(stdin.clone(), non_determinism.clone());
+        let test_program = ozk_parsing::compile_for_test(
+            "option_types",
+            "mutable_values",
+            "main",
+            crate::ast_types::ListType::Unsafe,
+        );
+        let expected_stack_diff = 0;
+        let vm_output = execute_compiled_with_stack_memory_and_ins_for_test(
+            &test_program,
+            vec![],
+            &HashMap::default(),
+            stdin,
+            NonDeterminism::default(),
+            expected_stack_diff,
+        )
+        .unwrap();
+        assert_eq!(native_output, vm_output.output);
+    }
+}

--- a/src/tests_and_benchmarks/ozk/programs/option_types/simple_is_some.rs
+++ b/src/tests_and_benchmarks/ozk/programs/option_types/simple_is_some.rs
@@ -1,0 +1,60 @@
+use triton_vm::BFieldElement;
+use twenty_first::shared_math::x_field_element::XFieldElement;
+
+use crate::tests_and_benchmarks::ozk::rust_shadows as tasm;
+
+#[allow(clippy::unnecessary_literal_unwrap)]
+fn main() {
+    let bfe: BFieldElement = tasm::tasm_io_read_stdin___bfe();
+    let some_bfe: Option<BFieldElement> = Some(bfe);
+    assert!(some_bfe.is_some());
+    tasm::tasm_io_write_to_stdout___u64(some_bfe.unwrap().value());
+
+    let xfe: XFieldElement = tasm::tasm_io_read_stdin___xfe();
+    let some_xfe: Option<XFieldElement> = Some(xfe);
+    assert!(some_xfe.is_some());
+    tasm::tasm_io_write_to_stdout___xfe(some_xfe.unwrap());
+
+    let none_xfe: Option<XFieldElement> = None;
+    assert!(none_xfe.is_none());
+
+    return;
+}
+
+mod test {
+    use std::collections::HashMap;
+    use std::default::Default;
+
+    use rand::random;
+    use triton_vm::NonDeterminism;
+
+    use crate::tests_and_benchmarks::ozk::{ozk_parsing, rust_shadows};
+    use crate::tests_and_benchmarks::test_helpers::shared_test::*;
+
+    use super::*;
+
+    #[test]
+    fn simple_is_some_test() {
+        let stdin = vec![random(), random(), random(), random()];
+        let non_determinism = NonDeterminism::default();
+        let native_output =
+            rust_shadows::wrap_main_with_io(&main)(stdin.clone(), non_determinism.clone());
+        let test_program = ozk_parsing::compile_for_test(
+            "option_types",
+            "simple_is_some",
+            "main",
+            crate::ast_types::ListType::Unsafe,
+        );
+        let expected_stack_diff = 0;
+        let vm_output = execute_compiled_with_stack_memory_and_ins_for_test(
+            &test_program,
+            vec![],
+            &HashMap::default(),
+            stdin,
+            NonDeterminism::default(),
+            expected_stack_diff,
+        )
+        .unwrap();
+        assert_eq!(native_output, vm_output.output);
+    }
+}

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -361,8 +361,8 @@ fn annotate_stmt(
         }
 
         ast::Stmt::Assign(ast::AssignStmt { identifier, expr }) => {
-            let (identifier_type, mutable) =
-                annotate_identifier_type(identifier, state, env_fn_signature);
+            let (identifier_type, mutable, _) =
+                annotate_identifier_type(identifier, None, state, env_fn_signature);
             let assign_expr_hint = &identifier_type;
             let expr_type =
                 derive_annotate_expr_type(expr, Some(assign_expr_hint), state, env_fn_signature)
@@ -644,30 +644,54 @@ pub fn assert_type_equals(
 /// Set type and return type and whether the identifier was declared as mutable
 pub(crate) fn annotate_identifier_type(
     identifier: &mut ast::Identifier<Typing>,
+    hint: Option<&ast_types::DataType>,
     state: &mut CheckState,
     fn_signature: &ast::FnSignature,
-) -> (ast_types::DataType, bool) {
+) -> (ast_types::DataType, bool, Option<ast::Expr<Typing>>) {
     match identifier {
         // x
-        ast::Identifier::String(var_name, var_type) => match state.vtable.get(var_name) {
-            Some(found_type) => {
-                *var_type = Typing::KnownType(found_type.data_type.clone());
-                (found_type.data_type.clone(), found_type.mutable)
-            }
-            None => match state.ftable.get(var_name) {
-                Some(functions) => {
-                    assert!(
-                        functions.len().is_one(),
-                        "Duplicate function name: {var_name}"
-                    );
-                    let function = functions[0].clone();
-                    *var_type = Typing::KnownType(function.clone().into());
-                    let function_datatype: ast_types::DataType = function.into();
-                    (function_datatype, false)
+        ast::Identifier::String(var_name, var_type) => {
+            match state.vtable.get(var_name) {
+                Some(found_type) => {
+                    // Identifier is a declared variable
+                    *var_type = Typing::KnownType(found_type.data_type.clone());
+                    (found_type.data_type.clone(), found_type.mutable, None)
                 }
-                None => panic!("variable {var_name} must have known type"),
-            },
-        },
+                None => match state.ftable.get(var_name) {
+                    // Identifier is a declared function
+                    Some(functions) => {
+                        assert!(
+                            functions.len().is_one(),
+                            "Duplicate function name: {var_name}"
+                        );
+                        let function = functions[0].clone();
+                        *var_type = Typing::KnownType(function.clone().into());
+                        let function_datatype: ast_types::DataType = function.into();
+                        (function_datatype, false, None)
+                    }
+                    None => {
+                        // Identifier is variant type declared in `prelude` without associated data, like `None`.
+                        let type_hint = match hint {
+                        Some(ty) => ty,
+                        None => panic!("type of variable or identifier \"{var_name}\" could not be resolved"),
+                    };
+                        let prelude_type = state
+                            .composite_types
+                            .prelude_variant_match(var_name, type_hint).expect("type of variable or identifier \"{var_name}\" could not be resolved");
+                        *var_type = Typing::KnownType(prelude_type.clone().into());
+
+                        (
+                            prelude_type.clone().into(),
+                            false,
+                            Some(ast::Expr::EnumDeclaration(ast::EnumDeclaration {
+                                enum_type: prelude_type.into(),
+                                variant_name: var_name.to_owned(),
+                            })),
+                        )
+                    }
+                },
+            }
+        }
 
         // x[e]
         ast::Identifier::Index(list_identifier, index_expr, known_type) => {
@@ -687,8 +711,8 @@ pub(crate) fn annotate_identifier_type(
             // type of `a` need to be forced to `Vec<T>`.
             // TODO: It's possible that the type of `list_identifier` needs to be forced to. But to
             // do that, this function probably needs the expression, and not just the identifier.
-            let (maybe_list_type, mutable) =
-                annotate_identifier_type(list_identifier, state, fn_signature);
+            let (maybe_list_type, mutable, _) =
+                annotate_identifier_type(list_identifier, None, state, fn_signature);
             let mut forced_sequence_type = maybe_list_type.clone();
             let element_type = loop {
                 if let ast_types::DataType::List(elem_ty, _) = &forced_sequence_type {
@@ -736,17 +760,18 @@ pub(crate) fn annotate_identifier_type(
             list_identifier.force_type(&forced_sequence_type);
             *known_type = Typing::KnownType(element_type.clone());
 
-            (element_type, mutable)
+            (element_type, mutable, None)
         }
 
         // x.foo
         ast::Identifier::Field(ident, field_id, annot) => {
-            let (receiver_type, mutable) = annotate_identifier_type(ident, state, fn_signature);
+            let (receiver_type, mutable, _) =
+                annotate_identifier_type(ident, None, state, fn_signature);
             // Only structs have fields, so receiver_type must be a struct, or a pointer to a struct.
             let data_type = receiver_type.field_access_returned_type(field_id);
             *annot = Typing::KnownType(data_type.clone());
 
-            (data_type, mutable)
+            (data_type, mutable, None)
         }
     }
 }
@@ -1049,13 +1074,23 @@ fn derive_annotate_expr_type(
             }
         }
 
-        ast::Expr::Var(identifier) => match identifier.resolved() {
-            Some(ty) => Ok(ty),
-            None => {
-                annotate_identifier_type(identifier, state, env_fn_signature);
-                Ok(identifier.get_type())
+        ast::Expr::Var(identifier) => {
+            let resolved = identifier.resolved().clone();
+            let (rewrite, ret) = match resolved {
+                Some(ty) => (None, Ok(ty.to_owned())),
+                None => {
+                    let (_, _, new_expr) =
+                        annotate_identifier_type(identifier, hint, state, env_fn_signature);
+                    (new_expr, Ok(identifier.get_type()))
+                }
+            };
+
+            if let Some(new_expr) = rewrite {
+                *expr = new_expr;
             }
-        },
+
+            ret
+        }
 
         ast::Expr::Tuple(tuple_exprs) => {
             let no_hint = None;


### PR DESCRIPTION
Add support for `Option<T>` types.

This one got more messy than I had hoped for, as the intermediate AST is rewritten from `Expr::Var` to `Expr::EnumDeclaration` in the type checker. I struggled a bit finding the right way of handling multiple instances of `None` (when multiple Option<T>) are in scope, and this is all I could come up with.

I added some `assert` statements to bind down the return value that is responsible for the `Expr::Var` -> `Expr::EnumDeclaration` rewrite. So at least we check at run-time when I couldn't handle at compile-time.